### PR TITLE
Hinweise auf sonstige Verben

### DIFF
--- a/doc/pcmd/erwidere
+++ b/doc/pcmd/erwidere
@@ -17,12 +17,14 @@ erwidere
     Aber aufgepasst: Du erwiderst wirklich nur die *letzte* Mitteilung! Wenn
     Du also den zu erwidernden Text schreibst, und jemand anderes teilt Dir in
     der Zwischenzeit auch noch etwas mit, so bekommt *er* die Antwort
-    zugeschickt!
+    zugeschickt! Dies gilt ebenfalls fuer sonstige Formen der Kommunikation, 
+    die andere Spieler Dir aus der Ferne zukommen lassen koennen, zum Beispiel
+    zuwinken oder knuddeln.
     
     Der gleiche Effekt kann mit "teile , mit <text>" erzielt werden.
 
  SIEHE AUCH:
-    teile (mit)
+    teile (mit), rwinke, rknuddle, (ab hier nur fuer Seher) remote, echo
 
  LETZTE AeNDERUNG:
-    Thu, 08.02.2007, 18:23:00 von Muadib
+    17.12.2016, 23:55:00 von Zaphob


### PR DESCRIPTION
 [Allgemein:Zesstra] @tm + erwidere: momentan wird das Ziel fuer erwidere eben
[Allgemein:Zesstra] nicht nur durch teile-mit geaendert. 
[Allgemein:Zaphob] Na sowas, da irrt sich dessen Hilfeseite. 
[Allgemein:Zesstra] Naja, haengt davon ab, wie man Mitteilung versteht. 
[Allgemein:Zaphob] Da steht Mitteilung und unten steht Siehe auch: teile
[Allgemein:Zaphob] (mit), also wenn da Verben erwaeht wuerden, vielleicht 
[Allgemein:Zesstra] Ist jedenfalls gerade so, dass auch emotes und soulbefehle
[Allgemein:Zesstra] das Ziel fuer erwidere aendern, weil das auch
[Allgemein:Zesstra] Kommunikation ist. 
[Allgemein:Zesstra] l Und das laesst sich auch nicht impel aendern. 