### PR TITLE
Neue URL der Kämpfer Gilde

### DIFF
--- a/doc/help/kaempfer
+++ b/doc/help/kaempfer
@@ -66,11 +66,11 @@ Die Kaempfergilde
  einen bereithaelt, zu erledigen.
 
  Wer sich noch mehr Informationen verschaffen moechte, schaut einfach mal
- auf http://www.trves.de vorbei.
+ auf http://mg.mud.de/gilden/kaempfer/index.shtml vorbei.
 
 
  SIEHE AUCH:
     attribute, ebenen, gilden
 
  LETZTE AeNDERUNG:
-    13.01.2018, Arathorn 
+    31.12.2018, Zaphob 


### PR DESCRIPTION
trves.de zeigt inzwischen aufs Anderland